### PR TITLE
Test suite passes on Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,4 @@ before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r requirements.txt --user `whoami`
 script: "make ci"
-after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html; do echo \"\"; echo \"$f:\"; lynx -dump $f; done"
+after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html`; do echo \"\"; echo \"$f:\"; lynx -dump $f; done; for f in `ls logs/ct_run*/*/log/erlang.log.*`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 sudo: true
 language: erlang
 otp_release: R16B03-1
-python: 2.7
 before_install:
+  - sudo apt-get install python-dev libffi-dev
   - sudo apt-get install bluez libbluetooth-dev lynx
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r requirements.txt --user `whoami`
 script: "make ci"
-after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html; do echo ""; echo "$f:"; lynx -dump $f; done"
+after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html; do echo \"\"; echo \"$f:\"; lynx -dump $f; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: erlang
 otp_release: R16B03-1
 python: 2.7
 before_install:
-  - sudo apt-get install bluez libbluetooth-dev
+  - sudo apt-get install bluez libbluetooth-dev lynx
 before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r requirements.txt --user `whoami`
 script: "make ci"
-after_failure: "echo 'logs/raw.log\n'; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done"
+after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html; do echo ""; echo "$f:"; lynx -dump $f; done"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,4 +8,10 @@ before_script:
   - export PATH=$HOME/.local/bin:$PATH
   - pip install -r requirements.txt --user `whoami`
 script: "make ci"
-after_failure: "echo 'logs/raw.log\n'; html2text logs/index.html; cat logs/raw.log; for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done; for f in `ls -1 logs/ct_run*/jlr.rvi_core.logs/run*/rvi_core_suite*.html`; do echo \"\"; echo \"$f:\"; lynx -dump $f; done; for f in `ls logs/ct_run*/*/log/erlang.log.*`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done"
+after_failure:
+  - "echo 'logs/raw.log\n'"
+  - "html2text logs/index.html"
+  - "cat logs/raw.log"
+  - "for f in `find logs/ct_run*/log*/ -type f`; do echo \"\n$f\n\" ; cat $f; done"
+  - "for f in `ls -1 logs/ct_run*/*.rvi_core.logs/run*/rvi_core_suite*.html`; do echo \"\"; echo \"$f:\"; lynx -dump $f; done"
+  - "for f in `ls logs/ct_run*/*/log/erlang.log.*`; do echo \"\"; echo \"$f:\"; echo \"\"; cat $f; done"

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@
 # Makefile for the RVI node.
 # 
 
-.PHONY:	all deps compile clean rpm rpmclean test xref ci
+.PHONY:	all deps compile clean rpm rpmclean test xref ci escript
 
 SCRIPTS=scripts/setup_gen \
 	scripts/author
@@ -54,8 +54,8 @@ xref: compile
 
 ci: xref test
 
-test: compile
-	rebar ct
+test: compile escript
+	rebar ct skip_deps=true
 
 # Create a SOURCES tarball for RPM
 rpm_tarball: rpmclean clean

--- a/components/authorize/src/author.erl
+++ b/components/authorize/src/author.erl
@@ -76,7 +76,7 @@ cmd("read_sig", Opts) ->
     {_, Pub} = get_key_pair(Root),
     case file:read_file(Sig) of
         {ok, JWT} ->
-            case authorize_sig:decode_jwt(JWT, Pub) of
+            case authorize_sig:decode_jwt(strip_nl(JWT), Pub) of
                 invalid ->
                     fail("Cannot validate ~s~n", [Sig]);
                 {Header, Payload} ->
@@ -182,6 +182,11 @@ l2i(Str) ->
 i2l(I) ->
     integer_to_list(I).
 
+strip_nl(Bin) ->
+    case re:split(Bin,"\\s+$",[{return,binary},trim]) of
+	[Trimmed] -> Trimmed;
+	_ -> Bin
+    end.
 
 make_auth(RPriv, Pub, Fmt, Opts) ->
     case Fmt of

--- a/components/authorize/src/authorize.app.src
+++ b/components/authorize/src/authorize.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { authorize_app, []}},
-  {start_phases, [{ json_rpc, []}]}
+  {start_phases, [{ json_rpc, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,authorize}]}
+	]}
  ]}.

--- a/components/authorize/src/authorize_app.erl
+++ b/components/authorize/src/authorize_app.erl
@@ -27,6 +27,9 @@ start_phase(json_rpc, _, _) ->
     authorize_rpc:start_json_server(),
     ok;
 
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, authorize});
+
 start_phase(_Other, _, _) ->
     ok.
 

--- a/components/dlink_bt/src/dlink_bt.app.src
+++ b/components/dlink_bt/src/dlink_bt.app.src
@@ -1,3 +1,4 @@
+%% -*- erlang-indent-level: 4;indent-tabs-mode: nil -*-
 %%
 %% Copyright (C) 2014, Jaguar Land Rover
 %%
@@ -16,8 +17,12 @@
   {applications, [
                   kernel,
                   stdlib,
-		  rvi_common
+		  rvi_common,
+		  bt
                  ]},
   {mod, { dlink_bt_app, []}},
-  {start_phases, [{json_rpc, []}, {connection_manager, []}]}
+  {start_phases, [{json_rpc, []}, {connection_manager, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,dlink_dt}]}
+	]}
  ]}.

--- a/components/dlink_bt/src/dlink_bt_app.erl
+++ b/components/dlink_bt/src/dlink_bt_app.erl
@@ -32,8 +32,10 @@ start_phase(json_rpc, _, _) ->
 
 start_phase(connection_manager, _, _) ->
     dlink_bt_rpc:start_connection_manager(),
-    ok.
+    ok;
 
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, dlink_bt}).
 
 stop(_State) ->
     ok.

--- a/components/dlink_sms/src/dlink_sms.app.src
+++ b/components/dlink_sms/src/dlink_sms.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { dlink_sms_app, []}},
-  {start_phases, [{json_rpc, []}, {connection_manager, []}]}
+  {start_phases, [{json_rpc, []}, {connection_manager, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,dlink_sms}]}
+	]}
  ]}.

--- a/components/dlink_sms/src/dlink_sms_app.erl
+++ b/components/dlink_sms/src/dlink_sms_app.erl
@@ -16,6 +16,8 @@
 	 start_phase/3,
 	 stop/1]).
 
+-include_lib("lager/include/log.hrl").
+
 %% ===================================================================
 %% Application callbacks
 %% ===================================================================
@@ -32,8 +34,10 @@ start_phase(json_rpc, _, _) ->
 
 start_phase(connection_manager, _, _) ->
     dlink_sms_rpc:start_connection_manager(),
-    ok.
+    ok;
 
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, dlink_sms}).
 
 stop(_State) ->
     ok.

--- a/components/dlink_tcp/src/dlink_tcp.app.src
+++ b/components/dlink_tcp/src/dlink_tcp.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { dlink_tcp_app, []}},
-  {start_phases, [{json_rpc, []}, {connection_manager, []}, {announce, []}]}
+  {start_phases, [{json_rpc, []}, {connection_manager, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,dlink_tcp}]}
+	]}
  ]}.

--- a/components/dlink_tcp/src/dlink_tcp_app.erl
+++ b/components/dlink_tcp/src/dlink_tcp_app.erl
@@ -16,6 +16,8 @@
 	 start_phase/3,
 	 stop/1]).
 
+-include_lib("lager/include/log.hrl").
+
 %% ===================================================================
 %% Application callbacks
 %% ===================================================================
@@ -35,8 +37,7 @@ start_phase(connection_manager, _, _) ->
     ok;
 
 start_phase(announce, _, _) ->
-    gproc:reg({n, l, dlink_tcp}),
-    ok.
+    rvi_common:announce({n, l, dlink_tcp}).
 
 stop(_State) ->
     ok.

--- a/components/proto_bert/src/proto_bert.app.src
+++ b/components/proto_bert/src/proto_bert.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { proto_bert_app, []}},
-  {start_phases, [{json_rpc, []}]}
+  {start_phases, [{json_rpc, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n, l, proto_bert}]}
+	]}
  ]}.

--- a/components/proto_bert/src/proto_bert_app.erl
+++ b/components/proto_bert/src/proto_bert_app.erl
@@ -29,7 +29,10 @@ start_phase(init, _, _) ->
 
 start_phase(json_rpc, _, _) ->
     proto_bert_rpc:start_json_server(),
-    ok.
+    ok;
+
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, proto_bert}).
 
 stop(_State) ->
     ok.

--- a/components/proto_json/src/proto_json.app.src
+++ b/components/proto_json/src/proto_json.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { proto_json_app, []}},
-  {start_phases, [{json_rpc, []}]}
+  {start_phases, [{json_rpc, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n, l, proto_json}]}
+	]}
  ]}.

--- a/components/proto_json/src/proto_json_app.erl
+++ b/components/proto_json/src/proto_json_app.erl
@@ -29,7 +29,10 @@ start_phase(init, _, _) ->
 
 start_phase(json_rpc, _, _) ->
     proto_json_rpc:start_json_server(),
-    ok.
+    ok;
+
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, proto_json}).
 
 stop(_State) ->
     ok.

--- a/components/schedule/src/schedule.app.src
+++ b/components/schedule/src/schedule.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { schedule_app, []}},
-  {start_phases, [{json_rpc, []}]}
+  {start_phases, [{json_rpc, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n, l, schedule}]}
+	]}
  ]}.

--- a/components/schedule/src/schedule_app.erl
+++ b/components/schedule/src/schedule_app.erl
@@ -27,10 +27,12 @@ start_phase(init, _, _) ->
     schedule_rpc:init(),
     ok;
 
-
 start_phase(json_rpc, _, _) ->
     schedule_rpc:start_json_server(),
-    ok.
+    ok;
+
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, schedule}).
 
 stop(_State) ->
     ok.

--- a/components/service_discovery/src/service_discovery.app.src
+++ b/components/service_discovery/src/service_discovery.app.src
@@ -19,5 +19,8 @@
 		  rvi_common
                  ]},
   {mod, { service_discovery_app, []}},
-  {start_phases, [{json_rpc, []}]}
+  {start_phases, [{json_rpc, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,service_discovery}]}
+	]}
  ]}.

--- a/components/service_discovery/src/service_discovery_app.erl
+++ b/components/service_discovery/src/service_discovery_app.erl
@@ -25,7 +25,9 @@ start(_StartType, _StartArgs) ->
 
 start_phase(json_rpc, _, _) ->
     service_discovery_rpc:start_json_server(),
-    ok.
+    ok;
+start_phase(announce, _, _) ->
+    rvi_common:announce({n,l,service_discovery}).
 
 stop(_State) ->
     ok.

--- a/components/service_edge/src/service_edge.app.src
+++ b/components/service_edge/src/service_edge.app.src
@@ -20,5 +20,8 @@
                  ]},
   {mod, { service_edge_app, []}},
 
-  {start_phases, [{json_rpc, []},{websocket, []}]}
+  {start_phases, [{json_rpc, []},{websocket, []}, {announce, []}]},
+  {env, [
+	 {rvi_core_await, [{n,l,service_edge}]}
+	]}
  ]}.

--- a/components/service_edge/src/service_edge_app.erl
+++ b/components/service_edge/src/service_edge_app.erl
@@ -29,7 +29,10 @@ start_phase(json_rpc, _, _) ->
 
 start_phase(websocket, _, _) ->
     service_edge_rpc:start_websocket(),
-    ok.
+    ok;
+
+start_phase(announce, _, _) ->
+    rvi_common:announce({n, l, service_edge}).
 
 stop(_State) ->
     ok.

--- a/src/rvi_app.erl
+++ b/src/rvi_app.erl
@@ -10,6 +10,8 @@
 -module(rvi_app).
 
 -behaviour(application).
+-include_lib("lager/include/log.hrl").
+
 
 %% Application callbacks
 -export([start/2,
@@ -24,8 +26,8 @@ start(_StartType, _StartArgs) ->
     rvi_sup:start_link().
 
 start_phase(announce, _, _) ->
-    gproc:reg({n,l,rvi_core}),
-    ok;
+    rvi_server:await();
+
 start_phase(ping, _, _) ->
 %%    exoport:ping(),
     ok.

--- a/src/rvi_core.app.src
+++ b/src/rvi_core.app.src
@@ -23,9 +23,6 @@
 		  lager,
 		  service_edge,
 		  authorize,
-		  dlink_tcp,
-		  bt,
-		  dlink_bt,
 		  proto_json,
 		  proto_bert
                  ]},

--- a/src/rvi_server.erl
+++ b/src/rvi_server.erl
@@ -1,0 +1,80 @@
+-module(rvi_server).
+-behaviour(gen_server).
+
+-export([start_link/0,
+	 await/0,
+	 info/0,
+	 info/1]).
+
+%% gen_server callbacks
+-export([init/1,
+	 handle_call/3,
+	 handle_cast/2,
+	 handle_info/2,
+	 terminate/2,
+	 code_change/3]).
+
+-include_lib("lager/include/log.hrl").
+
+-record(st, {wait_for = [],
+	     ready = []}).
+
+start_link() ->
+    gen_server:start_link({local,?MODULE}, ?MODULE, [], [{debug,[trace]}]).
+
+init([]) ->
+    WaitFor = lists:flatmap(
+		fun({_, Names}) ->
+			Names
+		end, setup:find_env_vars(rvi_core_await)),
+    {ok, #st{wait_for = WaitFor}}.
+
+await() ->
+    call(await).
+
+info() ->
+    call(info).
+
+info(waiting) -> call(waiting);
+info(ready  ) -> call(ready);
+info(_) ->
+    undefined.
+
+handle_call(ready, _From, #st{ready = Ready} = S) ->
+    {reply, Ready, S};
+handle_call(waiting, _From, #st{wait_for = WF} = S) ->
+    {reply, WF, S};
+handle_call(info, _From, #st{ready = Ready,
+			     wait_for = WF} = S) ->
+    {reply, [{ready, Ready},
+	     {waiting_for, WF}], S};
+handle_call(await, _From, #st{wait_for = WF} = S) ->
+    [gproc:nb_wait(Name) || Name <- WF],
+    {reply, ok, S};
+handle_call(_, _, S) ->
+    {reply, error, S}.
+
+handle_cast(_, S) ->
+    {noreply, S}.
+
+handle_info({gproc, _, registered, {Key, _, _}}, #st{wait_for = WF,
+						     ready = Ready} = S) ->
+    WF1 = WF -- [Key],
+    if WF1 == [] andalso WF =/= [] ->
+	    rvi_common:announce({n, l, rvi_core});
+       true ->
+	    ok
+    end,
+    {noreply, S#st{ready = [Key | Ready], wait_for = WF1}};
+handle_info(_, S) ->
+    {noreply, S}.
+
+terminate(_Reason, _State) ->
+    ok.
+
+code_change(_FromVsn, S, _Extra) ->
+    {ok, S}.
+
+
+call(Req) ->
+    gen_server:call(?MODULE, Req).

--- a/src/rvi_sup.erl
+++ b/src/rvi_sup.erl
@@ -34,6 +34,6 @@ start_link() ->
 init([]) ->
     {ok, { {one_for_one, 5, 10},
 	   [
-	    %% ?CHILD(rvi_server, worker)
+	    ?CHILD(rvi_server, worker)
 	   ]} }.
 

--- a/test/config/backend.config
+++ b/test/config/backend.config
@@ -2,6 +2,7 @@
 {ok, CurDir} = file:get_cwd().
 [
  {include_lib, "rvi_core/backend.config"},
+ {remove_apps, [bt, dlink_bt]},
  {set_env,
   [
    {rvi_core,

--- a/test/config/sample.config
+++ b/test/config/sample.config
@@ -2,6 +2,7 @@
 {ok, CurDir} = file:get_cwd().
 [
  {include_lib, "rvi_core/rvi_sample.config"},
+ {remove_apps, [bt, dlink_bt]},
  {set_env,
   [
    {rvi_core,


### PR DESCRIPTION
Note: Travis-CI needs to be enabled by the admin of each repository. I've done so for uwiger/rvi_core

Amended .travis.yml to collect more data from failing test suites.

This made it clear that the bluetooth components were causing problems.

To be able to disable bluetooth (adding {remove_apps, [bt, dlink_bt] in the config), I removed these apps (and others) from the rvi_core 'applications' list, and instead introduced a system of awaiting/announcing components using gproc:reg/1 and gproc:await/1. See rvi_server.erl
